### PR TITLE
add deps to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
         url = 'https://github.com/joeyism/py-edgar', # use the URL to the github repo
         download_url = 'https://github.com/joeyism/py-edgar/archive/0.3.0.tar.gz',
         keywords = ['edgar', 'sec'], 
+        install_requires = ['requests', 'lxml'],
         classifiers = [],
         )


### PR DESCRIPTION
When installed py-edgar via `pip install edgar` I needed to install some dependencies. 
This updates the setup.py to include installation requirements that were missing in my testing. I tested it by pip installing directly from repo/branch:

`pip install git+git://github.com/ipl31/py-edgar.git@dep`

