### PR TITLE
Made the get_documents function return html type

### DIFF
--- a/edgar/company.py
+++ b/edgar/company.py
@@ -80,7 +80,7 @@ def get_documents(tree, no_of_documents=1):
         content_page = get_request(url)
         url = BASE_URL + content_page.xpath('//*[@id="formDiv"]/div/table/tr[2]/td[3]/a')[0].attrib["href"]
         filing = get_request(url)
-        result.append(filing.body.text_content())
+        result.append(filing)
 
     if len(result) == 1:
         return result[0]


### PR DESCRIPTION
Hi Joey, as user, I suggest having get_documents return a type that's consistent with the output of company.get_10K(). With the update I made users are now able to do this:
company = Company(name, ciq)
tree = company.get_all_filings(filing_type="10-K")#YYYYMMDD
docs = get_documents(tree, no_of_documents=2) 
text = TXTML.parse_full_10K(docs[0])