### PR TITLE
Fixed get_CIK_from_company class method

### DIFF
--- a/edgar/company.py
+++ b/edgar/company.py
@@ -143,4 +143,4 @@ class Company():
         names_list = []
         for elem in tree.xpath('//*[@id="seriesDiv"]/table/tr[*]/td[2]'):
             names_list.append(elem.text_content())
-        return list(zip(CIKList, namesList))
+        return list(zip(CIKList, names_list))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
 lxml
-edgar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 lxml
+edgar


### PR DESCRIPTION
Hi, 

I noticed that the get_CIK_from_company class method gave an error due to returning a non-existing list. I corrected it and now it returns a list of CIKs and companies, as expected. I also added the updated the requirements.txt so edgar is also installed.