### PR TITLE
Allow Edgar class to accept local file containing CIK lookup data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ edgar = Edgar()
 possible_companies = edgar.find_company_name("Cisco System")
 ```
 
+To avoid pull of all company data from sec.gov on Edgar initialization, pass in a local path to the data
+
+``` python
+from edgar import Edgar
+edgar = Edgar("/path/to/cik-lookup-data.txt")
+possible_companies = edgar.find_company_name("Cisco System")
+```
+
+
 To get XBRL data, run
 ```python
 from edgar import Company, XBRL, XBRLElement

--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,14 @@ To get all companies and find a specific one, run
    edgar = Edgar()
    possible_companies = edgar.find_company_name("Cisco System")
 
+To avoid pull of all company data from sec.gov on Edgar initialization, pass in a local path to the data
+
+.. code-block:: python
+
+   from edgar import Edgar
+   edgar = Edgar("/path/to/cik-lookup-data.txt")
+   possible_companies = edgar.find_company_name("Cisco System")
+
 To get XBRL data, run
 
 .. code-block:: python

--- a/edgar/__init__.py
+++ b/edgar/__init__.py
@@ -6,7 +6,7 @@ from .company import Company
 from .xbrl import XBRL, XBRLElement
 from .document import Document, Documents
 
-__version__ = "5.4.1"
+__version__ = "5.4.2"
 
 modules = glob.glob(dirname(__file__)+"/*.py")
 __all__ = [ basename(f)[:-3] for f in modules if isfile(f) and not f.endswith('__init__.py')]

--- a/edgar/edgar.py
+++ b/edgar/edgar.py
@@ -1,14 +1,19 @@
 from typing import Tuple, List, Any, Dict
 from lxml import html
 from tqdm import tqdm
+import os
 import requests
 from fuzzywuzzy import process, fuzz
 
 class Edgar():
 
-    def __init__(self):
-        all_companies_page = requests.get("https://www.sec.gov/Archives/edgar/cik-lookup-data.txt")
-        all_companies_content = all_companies_page.content.decode("latin1")
+    def __init__(self, companies_page_path=None):
+        all_companies_content : str
+        if companies_page_path is not None and os.path.isfile(companies_page_path):
+            all_companies_content = open(companies_page_path, encoding="latin-1").read()
+        else:
+            all_companies_page = requests.get("https://www.sec.gov/Archives/edgar/cik-lookup-data.txt")
+            all_companies_content = all_companies_page.content.decode("latin1")
         all_companies_array = all_companies_content.split("\n")
         del all_companies_array[-1]
         all_companies_array_rev = []


### PR DESCRIPTION
The ability to search for company names is incredibly useful.  However, the download of the ~30MB cik-lookup-data.txt file from sec.gov on each instantiation of the Edgar class is not ideal for inclusion of the class in regression testing or for when slower connections are being utilized.

This pull request allows the lookup data to be downloaded "out-of-band" and supplied to the Edgar class as an initialization argument specifying the full local path to the file.