### PR TITLE
allow tqdm progress indicator in match_company_by_company_name() to be optional

### DIFF
--- a/edgar/edgar.py
+++ b/edgar/edgar.py
@@ -29,9 +29,11 @@ class Edgar():
     def get_cik_by_company_name(self, name) -> str:
         return self.all_companies_dict[name]
 
-    def match_company_by_company_name(self, name, top=5) -> List[Dict[str, Any]]:
+    def match_company_by_company_name(self, name, top=5, progress=True) -> List[Dict[str, Any]]:
         result = []
-        for company, cik in tqdm(self.all_companies_dict.items()):
+        for company, cik in (
+            tqdm(self.all_companies_dict.items()) if progress else self.all_companies_dict.items()
+        ):
             result.append({"company_name": company, "cik": cik, "score": fuzz.partial_ratio(name, company)})
         return sorted(result, key=lambda row: row["score"], reverse=True)[:top]
 


### PR DESCRIPTION
While the tqdm progress indicator is great for showing feedback for the long-running edgar.match_company_by_company_name(), the library may be used in projects where other progress indicators are already being used, such as [halo](https://github.com/manrajgrover/halo), and tqdm might conflict with existing spinners.

As a result, include an optional "progress" flag to match_company_by_company_name() which defaults to True, but allows the caller to indicate the progress indicator should not be shown.